### PR TITLE
revert to eb9531a, set version 0.5.0, simplify publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Publish Extension
+name: Publish to npm
 
 on:
   push:
@@ -6,78 +6,10 @@ on:
       - 'v*'
   workflow_dispatch:
 
-env:
-  CARGO_INCREMENTAL: 0
-
 jobs:
-  build-native:
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - os: macos-latest
-            target: x86_64-apple-darwin
-            node_file: unbrowse-native.darwin-x64.node
-          - os: macos-latest
-            target: aarch64-apple-darwin
-            node_file: unbrowse-native.darwin-arm64.node
-          - os: ubuntu-latest
-            target: x86_64-unknown-linux-gnu
-            node_file: unbrowse-native.linux-x64-gnu.node
-          # Linux ARM64 disabled - needs cross-compilation setup
-          # - os: ubuntu-latest
-          #   target: aarch64-unknown-linux-gnu
-          #   node_file: unbrowse-native.linux-arm64-gnu.node
-          - os: windows-latest
-            target: x86_64-pc-windows-msvc
-            node_file: unbrowse-native.win32-x64-msvc.node
-
-    runs-on: ${{ matrix.os }}
-    name: Build ${{ matrix.target }}
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '22'
-
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: ${{ matrix.target }}
-
-      - name: Install cross-compiler (Linux ARM64)
-        if: matrix.target == 'aarch64-unknown-linux-gnu'
-        run: sudo apt-get update && sudo apt-get install -y gcc-aarch64-linux-gnu
-
-      - name: Install native dependencies
-        run: cd native && npm install
-
-      - name: Build native addon
-        run: cd native && npm run build -- --target ${{ matrix.target }}
-
-      - name: Strip binary (Unix)
-        if: runner.os != 'Windows'
-        run: |
-          cd native
-          if [ "${{ matrix.target }}" = "aarch64-unknown-linux-gnu" ]; then
-            aarch64-linux-gnu-strip *.node || true
-          else
-            strip -x *.node || strip *.node || true
-          fi
-
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ matrix.node_file }}
-          path: native/*.node
-
   publish:
     name: Publish to npm
     runs-on: ubuntu-latest
-    needs: build-native
 
     steps:
       - uses: actions/checkout@v4
@@ -87,19 +19,6 @@ jobs:
         with:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
-
-      - name: Download all native binaries
-        uses: actions/download-artifact@v4
-        with:
-          path: native-artifacts
-
-      - name: Move binaries to native/
-        run: |
-          mkdir -p native
-          for dir in native-artifacts/*/; do
-            cp "$dir"*.node native/ 2>/dev/null || true
-          done
-          ls -la native/
 
       - name: Install dependencies
         run: npm install

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Publish to npm
+name: Publish Extension
 
 on:
   push:
@@ -6,10 +6,78 @@ on:
       - 'v*'
   workflow_dispatch:
 
+env:
+  CARGO_INCREMENTAL: 0
+
 jobs:
+  build-native:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-latest
+            target: x86_64-apple-darwin
+            node_file: unbrowse-native.darwin-x64.node
+          - os: macos-latest
+            target: aarch64-apple-darwin
+            node_file: unbrowse-native.darwin-arm64.node
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            node_file: unbrowse-native.linux-x64-gnu.node
+          # Linux ARM64 disabled - needs cross-compilation setup
+          # - os: ubuntu-latest
+          #   target: aarch64-unknown-linux-gnu
+          #   node_file: unbrowse-native.linux-arm64-gnu.node
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+            node_file: unbrowse-native.win32-x64-msvc.node
+
+    runs-on: ${{ matrix.os }}
+    name: Build ${{ matrix.target }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Install cross-compiler (Linux ARM64)
+        if: matrix.target == 'aarch64-unknown-linux-gnu'
+        run: sudo apt-get update && sudo apt-get install -y gcc-aarch64-linux-gnu
+
+      - name: Install native dependencies
+        run: cd native && npm install
+
+      - name: Build native addon
+        run: cd native && npm run build -- --target ${{ matrix.target }}
+
+      - name: Strip binary (Unix)
+        if: runner.os != 'Windows'
+        run: |
+          cd native
+          if [ "${{ matrix.target }}" = "aarch64-unknown-linux-gnu" ]; then
+            aarch64-linux-gnu-strip *.node || true
+          else
+            strip -x *.node || strip *.node || true
+          fi
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.node_file }}
+          path: native/*.node
+
   publish:
     name: Publish to npm
     runs-on: ubuntu-latest
+    needs: build-native
 
     steps:
       - uses: actions/checkout@v4
@@ -19,6 +87,19 @@ jobs:
         with:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
+
+      - name: Download all native binaries
+        uses: actions/download-artifact@v4
+        with:
+          path: native-artifacts
+
+      - name: Move binaries to native/
+        run: |
+          mkdir -p native
+          for dir in native-artifacts/*/; do
+            cp "$dir"*.node native/ 2>/dev/null || true
+          done
+          ls -la native/
 
       - name: Install dependencies
         run: npm install

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getfoundry/unbrowse-openclaw",
-  "version": "0.2.2",
+  "version": "0.5.0",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -22,12 +22,6 @@
   ],
   "files": [
     "dist/",
-    "native/index.js",
-    "native/index.d.ts",
-    "native/unbrowse-native.darwin-arm64.node",
-    "native/unbrowse-native.darwin-x64.node",
-    "native/unbrowse-native.linux-x64-gnu.node",
-    "native/unbrowse-native.win32-x64-msvc.node",
     "hooks/",
     "openclaw.plugin.json",
     "clawdbot.plugin.json"


### PR DESCRIPTION
Reset to commit eb9531a (generate api.ts client for downloaded skills).
Bump version to 0.5.0 for npm publish. Simplify GitHub Actions
publish workflow to build TypeScript and publish directly without
native Rust addon builds. Remove native binary references from
package files list.

https://claude.ai/code/session_01CYE1Q2sM5prhzDizFm6H46