### PR TITLE
Warn when OpenClaw gateway auth is missing

### DIFF
--- a/packages/plugin/src/plugin/plugin.ts
+++ b/packages/plugin/src/plugin/plugin.ts
@@ -113,6 +113,14 @@ function deriveBrowserControlPort(gatewayPort: number): number {
   return gatewayPort + 2;
 }
 
+function hasGatewayAuth(rootConfig: any): boolean {
+  const auth = rootConfig?.gateway?.auth;
+  if (!auth || typeof auth !== "object") return false;
+  const token = typeof auth.token === "string" ? auth.token.trim() : "";
+  const password = typeof auth.password === "string" ? auth.password.trim() : "";
+  return token.length > 0 || password.length > 0;
+}
+
 // ── Plugin ────────────────────────────────────────────────────────────────────
 
 const plugin = {
@@ -237,6 +245,13 @@ const plugin = {
     }
     if (publishValidationWithAuth) {
       logger.info("[unbrowse] Publish-time auth validation ENABLED (opt-in)");
+    }
+
+    if (!isDiagnosticMode && !hasGatewayAuth(rootConfig)) {
+      logger.warn(
+        "[unbrowse] Gateway auth is not configured. Browser control APIs may be reachable by other local processes. " +
+        "Set gateway.auth.token (recommended) or gateway.auth.password in OpenClaw config.",
+      );
     }
     if (!autoContributeEnabled) {
       logger.info("[unbrowse] Auto-contribute DISABLED — skills will stay local only. Set autoContribute: true to earn revenue from contributions.");


### PR DESCRIPTION
### Motivation
- OpenClaw's security audit flags missing gateway/browser-control authentication as a critical risk, so the plugin should surface a clear, actionable warning at startup to help users secure their instance.

### Description
- Add a `hasGatewayAuth(rootConfig)` helper that detects whether `gateway.auth.token` or `gateway.auth.password` is configured.
- Emit a startup `logger.warn` when the plugin is not in diagnostic mode and no gateway auth is present, instructing users to set `gateway.auth.token` (recommended) or `gateway.auth.password` in OpenClaw config.
- Changes made in `packages/plugin/src/plugin/plugin.ts` and only affect normal startup (diagnostic commands like `doctor`/`audit` remain unaffected).

### Testing
- Ran TypeScript checks with `npm run typecheck`, which completed successfully.
- Executed OpenClaw audit for context using `mise exec node@22 -- pnpm dlx openclaw security audit --deep`, which ran and reported the host gateway security posture (used to validate the change does not interfere with diagnostic behavior).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699474824c5c832da6920ab58fd9553f)