### PR TITLE
docs: rebuild public docs as audience-tracked GitBook

### DIFF
--- a/docs/.gitbook.yaml
+++ b/docs/.gitbook.yaml
@@ -1,0 +1,3 @@
+structure:
+  readme: README.md
+  summary: SUMMARY.md

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,20 @@
+# Unbrowse
+
+Unbrowse is an API-native browser for AI agents. It lets an agent reach the data and actions behind a website without driving the website's visible interface every time.
+
+Most AI agents use the web the way a tired human would: open the page, wait for it to load, click through menus, fight popups, fill forms, wait again. Unbrowse learns the structured request path behind a site once, then reuses it. When a site genuinely needs a real browser session (cookies, sign-in, redirect handling), Unbrowse keeps that browser context in the loop. Same permissions, less ceremony.
+
+This documentation is organised by who is reading it.
+
+* **Start Here** explains what Unbrowse is in plain language, no background assumed.
+* **For Agents** is the operating model for an AI agent calling Unbrowse.
+* **For Developers** is how to integrate it in code.
+* **Concepts** is the conceptual model behind the system, drawn from the published papers.
+* **For Investors** is the wedge, the moat, and where to read the research.
+
+The two papers this documentation draws from:
+
+* [Internal APIs Are All You Need](https://arxiv.org/abs/2604.00694) on shared route discovery and the case against browser-first agent architectures.
+* The Unbrowse Maintenance Network paper on trust, accountability, and optional bonding in a shared route graph.
+
+Source and licensing scope is described in the [Open Source Notice](OPEN-SOURCE-NOTICE.md).

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -1,0 +1,50 @@
+# Table of contents
+
+* [Unbrowse](README.md)
+
+## Start Here
+
+* [What Is Unbrowse](start-here/what-is-unbrowse.md)
+* [The Browser-Discovery Tax](start-here/the-browser-discovery-tax.md)
+* [The Shared Route Graph](start-here/the-shared-route-graph.md)
+* [In Plain English](start-here/in-plain-english.md)
+
+## For Agents
+
+* [How an Agent Uses Unbrowse](for-agents/how-an-agent-uses-unbrowse.md)
+* [Resolve and Execute](for-agents/resolve-and-execute.md)
+* [MCP Integration](for-agents/mcp-integration.md)
+* [When It Uses a Browser](for-agents/when-it-uses-a-browser.md)
+
+## For Developers
+
+* [Integration Surfaces](for-developers/integration-surfaces.md)
+* [The Route Lifecycle](for-developers/the-route-lifecycle.md)
+* [SDK Quickstart](for-developers/sdk-quickstart.md)
+
+## Concepts
+
+* [Shadow APIs](concepts/shadow-apis.md)
+* [The Route Graph as a Productive Asset](concepts/route-graph-as-asset.md)
+* [The Maintenance Problem](concepts/the-maintenance-problem.md)
+* [Trust and Accountability](concepts/trust-and-accountability.md)
+* [How Quality Is Evaluated](concepts/evaluation-framing.md)
+
+## For Investors
+
+* [The Wedge](for-investors/the-wedge.md)
+* [The Moat](for-investors/the-moat.md)
+* [Market Framing](for-investors/market-framing.md)
+* [Read the Papers](for-investors/read-the-papers.md)
+
+## SDK Reference
+
+* [Build on Unbrowse](sdk/build-on-unbrowse.md)
+* [Developer Recipes](sdk/developer-recipes.md)
+* [Onboarding Users](sdk/onboarding-users.md)
+* [Onboarding Validators](sdk/onboarding-validators.md)
+* [Rewards and Economics](sdk/rewards-and-economics.md)
+
+## Reference
+
+* [Open Source Notice](OPEN-SOURCE-NOTICE.md)

--- a/docs/concepts/evaluation-framing.md
+++ b/docs/concepts/evaluation-framing.md
@@ -1,0 +1,12 @@
+# How Quality Is Evaluated
+
+Unbrowse is judged by whether an agent actually got the data the intent asked for, not by whether a call returned a 200.
+
+The canonical check is an agent-experience harness: it runs real intents end to end, collects the artifacts (what was returned, from where, how long it took), and an agent judges whether the result satisfied the intent. There is no regex pass or fail, because a page can return HTTP 200 and still be a captcha, an empty array, or the wrong shape. Evidence is collected; judgement is made against the intent.
+
+The paper separates two performance regimes, and it is worth keeping them distinct when reading any claim:
+
+* **Warmed-cache** performance: the route already exists in the graph, so the cost is a lookup and a call.
+* **Cold-start** performance: the route has to be learned live first, which is the expensive path the wedge is designed to amortise.
+
+A claim about speed or cost only means something once you know which regime it describes. Aggregate cost and network-growth analysis live in the published paper; specific internal numbers move and are not pinned here. Current live metrics are exposed at the public stats endpoint rather than baked into this page, because numbers in prose go stale.

--- a/docs/concepts/route-graph-as-asset.md
+++ b/docs/concepts/route-graph-as-asset.md
@@ -1,0 +1,9 @@
+# The Route Graph as a Productive Asset
+
+A route graph is not a static registry; it is a productive asset with upkeep costs.
+
+The Maintenance Network paper makes this distinction directly: a registry is written once and assumed correct, while a route graph that carries real agent traffic produces ongoing value and therefore incurs ongoing cost. Routes fail, authentication flows change, schemas drift, and previously valid execution plans decay. The graph is worth something precisely because it is kept current, not because it was once complete.
+
+This framing matters because it explains why discovery alone is insufficient. A graph that only accumulates routes and never maintains them degrades toward noise as the web changes underneath it. The value is in the freshness, not the count.
+
+Treating the graph as an asset with upkeep is what makes the maintenance problem, and the accountability question that follows it, unavoidable rather than optional.

--- a/docs/concepts/shadow-apis.md
+++ b/docs/concepts/shadow-apis.md
@@ -1,0 +1,9 @@
+# Shadow APIs
+
+Every website an agent visits is already an API; the browser is just the client.
+
+When a page loads or a button is clicked, the browser issues structured requests to the site's own backend and renders the responses. Those requests are the shadow API: a real, working interface that exists whether or not the site documents one. A browser-first agent ignores this layer and re-derives the same outcome through the visible page every time.
+
+The published paper's argument is that internal APIs are all you need: most agent web tasks reduce to a request the browser was already going to make, so an agent that learns that request can skip the interface. This reframes web automation from "control a browser" to "discover and reuse the request behind the browser."
+
+Shadow APIs are per-site and undocumented, which is why they have to be discovered from real use rather than looked up. How discovered routes are stored and kept useful is the subject of the next pages. The deeper extraction mechanics are described at the paper's level of abstraction and not below it.

--- a/docs/concepts/the-maintenance-problem.md
+++ b/docs/concepts/the-maintenance-problem.md
@@ -1,0 +1,9 @@
+# The Maintenance Problem
+
+Once a shared route graph carries meaningful traffic, the hard question is no longer discovery but maintenance.
+
+The first product claim, that shared lookup beats browser rediscovery on cost, latency, and reliability, is enough to justify the wedge and needs no token or economy to be true. The Maintenance Network paper is explicit that the wedge already works without a native asset. The second question only arrives later: once many agents depend on the graph, how is route quality coordinated over time?
+
+That second question is a coordination problem, not just an engineering one. It involves participants who discover routes, normalise them, keep them fresh, challenge stale or dishonest claims, and accept some accountability for quality. Simple access payments do not solve this, because paying to call a route says nothing about whether the route is still good.
+
+The paper's framing is deliberately quiet here: the interesting layer is a maintenance network with accountable participants and challenge mechanisms, not a louder token story. Trust and accountability are treated next, at that same restrained altitude.

--- a/docs/concepts/trust-and-accountability.md
+++ b/docs/concepts/trust-and-accountability.md
@@ -1,0 +1,9 @@
+# Trust and Accountability
+
+In a shared route graph, trust is a practical signal about whether a route still does what it claims, not a cryptographic guarantee.
+
+The shipped model is reliability-oriented: routes carry success and failure behaviour, freshness, verification state, and folded-in feedback, and that composite signal moves good routes up and bad routes out of future shortlists. This is a continuous trust model in the sense the paper uses: quality is observed from real outcomes over time rather than asserted once at publish.
+
+The Maintenance Network paper then asks how a graph should express trust and enforce accountability once it carries meaningful traffic. Its answer is deliberately narrow. Higher-trust route tiers, accountable maintainers, and challenge mechanisms are the coordination tools; optional bonding may become useful as one mechanism among others, and the FDRY asset is best understood only in that narrow role. The paper is explicit that this is a quieter accountability layer, not a token-first redesign of the product.
+
+What does not exist today, and is described as forward-looking rather than shipped, is a full validator market, staking and slashing, or cryptographic attestation. The honest reading: practical reliability and verification ship now; the richer accountability economy is research direction, not current behaviour.

--- a/docs/for-agents/how-an-agent-uses-unbrowse.md
+++ b/docs/for-agents/how-an-agent-uses-unbrowse.md
@@ -1,0 +1,16 @@
+# How an Agent Uses Unbrowse
+
+This page is the operating model for an AI agent that has Unbrowse available as a tool.
+
+The mental model is two steps, not one. The agent describes an intent and a target. Unbrowse returns a ranked shortlist of routes that could satisfy it, each with evidence (what it returns, what it needs, how reliable it has been). The agent's own reasoning picks the route that matches the intent, then calls execute on it. Unbrowse does not silently decide for the agent; it filters out the wrong routes and surfaces the evidence on the rest.
+
+The loop in practice:
+
+1. **Resolve** the intent against the shared graph and local cache.
+2. **Read the shortlist.** Each candidate carries enough evidence to judge fit.
+3. **Execute** the chosen route.
+4. **Give feedback** on whether the result satisfied the intent. This keeps good routes ranked and bad ones out of the way.
+
+If nothing in the graph fits, Unbrowse can open a browse session and learn the site live; the agent drives that session and Unbrowse indexes it passively so the next agent does not have to.
+
+The single most important habit: treat resolve and execute as separate decisions. Resolve gathers options; the agent judges; execute commits.

--- a/docs/for-agents/mcp-integration.md
+++ b/docs/for-agents/mcp-integration.md
@@ -1,0 +1,28 @@
+# MCP Integration
+
+The Model Context Protocol server is the supported way for an agent host to use Unbrowse.
+
+Add Unbrowse as an MCP server in the host config (Claude, Cursor, Codex, or any MCP-compatible client):
+
+```json
+{
+  "mcpServers": {
+    "unbrowse": {
+      "command": "npx",
+      "args": ["-y", "unbrowse", "mcp"]
+    }
+  }
+}
+```
+
+Then run setup once on the host machine:
+
+```bash
+npx unbrowse setup
+```
+
+Setup bootstraps the local runtime, accepts terms, registers an agent identity, and pairs a wallet for payment where relevant.
+
+The MCP server exposes the resolve and execute contract from the previous page as discoverable tools with structured schemas, plus the browse-session tools used when a site has to be learned live. The skill path that earlier versions shipped (a single `SKILL.md` document) was retired; MCP and the SDK are the two supported surfaces. The CLI is the same runtime for shell and CI use.
+
+If you are integrating from code rather than an agent host, see For Developers.

--- a/docs/for-agents/resolve-and-execute.md
+++ b/docs/for-agents/resolve-and-execute.md
@@ -1,0 +1,26 @@
+# Resolve and Execute
+
+Resolve and execute are deliberately two calls so that the picking decision stays with the agent's reasoning, not with a heuristic.
+
+## Resolve
+
+Resolve takes an intent (a natural-language task) and usually a URL or domain. It returns a ranked shortlist of candidate routes. Each candidate carries evidence the agent can judge against the intent:
+
+* the route and what it returns
+* what inputs it requires and what it yields
+* a reliability and freshness signal
+* the action kind (read versus write)
+
+Resolve searches local cache and the shared graph first. It only falls back to live capture when reuse genuinely fails.
+
+## Execute
+
+Execute runs one chosen route. The agent passes the route (or the resolve result) plus any parameters. The response is the data the intent asked for. Projection options control the shape of the response so the agent gets the content it needs rather than the schema.
+
+## Why two calls
+
+A single auto-executing call would force a machine to guess which route the agent meant. The two-call contract keeps that judgement in the calling model, which is the part that actually understands the intent. Unbrowse's job is to make the shortlist correct and the evidence honest, not to choose.
+
+## After execute
+
+Send feedback. Feedback is what keeps a reused graph trustworthy: routes that satisfy intents stay ranked, routes that stop working fall away.

--- a/docs/for-agents/when-it-uses-a-browser.md
+++ b/docs/for-agents/when-it-uses-a-browser.md
@@ -1,0 +1,16 @@
+# When It Uses a Browser
+
+Unbrowse keeps a real browser in the loop only when the site genuinely depends on browser-bound state, and treats opening one as a cost to avoid, not a feature.
+
+A browser session is used when the task needs things a bare request cannot carry:
+
+* sign-in and session cookies
+* cross-site request tokens
+* redirect chains
+* stricter authenticated single-page behaviour
+
+For everything else, the reused route is cheaper and faster, so that path is preferred.
+
+When live capture is unavoidable, Unbrowse opens a browse session, the agent drives it (navigate, snapshot, click, fill, submit), and the traffic is indexed passively so the next agent with the same intent does not have to repeat the session. The result is that browser use trends toward zero as the shared graph fills, rather than being paid on every run.
+
+The operating principle: a browser open during normal operation is a multi-step event to be designed out, not relied on.

--- a/docs/for-developers/integration-surfaces.md
+++ b/docs/for-developers/integration-surfaces.md
@@ -1,0 +1,15 @@
+# Integration Surfaces
+
+There are three ways to call Unbrowse from your own software. They are the same runtime behind different front doors.
+
+| Surface | Use it when | Entry point |
+|---|---|---|
+| **MCP server** | You are wiring an agent host (Claude, Cursor, Codex, any MCP client) | `npx unbrowse mcp` |
+| **`@unbrowse/sdk`** | You are writing TypeScript or JavaScript | `npm install @unbrowse/sdk` |
+| **CLI** | Shell scripts, CI, one-off use | `npx unbrowse` |
+
+All three speak to the same local runtime. The runtime defaults to `http://localhost:6969`.
+
+The earlier skill path (a single `SKILL.md` shipped through the repo) was retired. MCP and the SDK are the supported integration surfaces; the CLI is the same runtime for direct use.
+
+The SDK is MIT licensed and is the path most code should take. It auto-spawns the runtime if one is not already listening, so a single call takes you from install to first resolve. See [SDK Quickstart](./sdk-quickstart.md) and the SDK reference under `sdk/`.

--- a/docs/for-developers/sdk-quickstart.md
+++ b/docs/for-developers/sdk-quickstart.md
@@ -1,0 +1,31 @@
+# SDK Quickstart
+
+`@unbrowse/sdk` is the thin TypeScript client for the local runtime. It auto-spawns the runtime if one is not running.
+
+```bash
+npm install @unbrowse/sdk
+```
+
+```ts
+import { Unbrowse } from "@unbrowse/sdk";
+
+// Probe localhost, spawn the runtime if nothing is listening. The common case.
+const u = await Unbrowse.local();
+
+const resolved = await u.resolve({
+  intent: "list tomorrow's events",
+  url: "https://calendar.google.com",
+});
+
+const result = await u.execute(resolved, { projection: { raw: true } });
+```
+
+Three factories, three lifecycles:
+
+* `Unbrowse.local()` probes `127.0.0.1:6969` and spawns the runtime if needed. Right most of the time.
+* `Unbrowse.connect(url)` attaches to a runtime you already manage.
+* `Unbrowse.spawn({ port })` always spawns a fresh, owned runtime. Useful in tests.
+
+Reused routes can be priced. A paid call returns an HTTP 402 that the SDK raises as a typed error you can catch and retry after settling payment; brand-new agents get a sponsored allowance first. The full SDK reference, including the payment helpers and the typed error hierarchy, lives in the `sdk/` section of this space and in the package README.
+
+The SDK is MIT licensed. The runtime it talks to is distributed as a binary. The split is described in the [Open Source Notice](../OPEN-SOURCE-NOTICE.md).

--- a/docs/for-developers/the-route-lifecycle.md
+++ b/docs/for-developers/the-route-lifecycle.md
@@ -1,0 +1,15 @@
+# The Route Lifecycle
+
+This page describes, at a conceptual level, what happens to a route from first discovery to retirement. It is the model, not the implementation.
+
+A route moves through a small set of states:
+
+1. **Discovered.** An agent completed a task live and the structured request path behind it was recorded with what it needs and what it returns.
+2. **Published.** The route entered the shared graph so other agents with the same intent can find it.
+3. **Reused.** Resolve ranked it into a shortlist, an agent executed it, and the outcome fed back.
+4. **Scored.** Reliability, freshness, and verification state move the route up or down in future shortlists.
+5. **Drifted or retired.** When a site changes and a route stops returning what it used to, it is detected, demoted, and eventually deprecated so it stops misleading callers.
+
+The practical consequence for an integrator: a route is not a frozen cURL string. It carries enough state for the system to keep good ones hot and route around dead ones, which is why reuse stays reliable as sites change. The deeper mechanics of discovery, scoring, and verification are described conceptually in the published paper and are out of scope here.
+
+For what is and is not open, see the [Open Source Notice](../OPEN-SOURCE-NOTICE.md).

--- a/docs/for-investors/market-framing.md
+++ b/docs/for-investors/market-framing.md
@@ -1,0 +1,9 @@
+# Market Framing
+
+The addressable surface is every repeated web task an AI agent performs, which is most of what agents are being built to do.
+
+The shift underway is from agents that occasionally browse to agents that run web tasks continuously and at volume, and at volume the browser-first cost structure is the bottleneck rather than the model. Unbrowse sits underneath that workload as the layer that decides whether a task needs a browser at all, which is a position that grows with agent adoption rather than competing with any single agent product.
+
+The reason this is a layer and not a feature is that it is consumed the same way regardless of which agent framework or model sits on top, so it benefits from the whole category expanding instead of betting on one winner. That is the difference between selling a tool an agent chooses and being the path agent traffic routes through.
+
+Where this goes beyond the wedge (the maintained graph becoming shared infrastructure) is deliberately the quieter half of the story; the papers state it plainly without overclaiming it as shipped.

--- a/docs/for-investors/read-the-papers.md
+++ b/docs/for-investors/read-the-papers.md
@@ -1,0 +1,10 @@
+# Read the Papers
+
+The primary sources for diligence are the two papers, not this summary.
+
+* **[Internal APIs Are All You Need](https://arxiv.org/abs/2604.00694)** is the core paper: shadow APIs, shared discovery, the case against browser-first agent architectures, the economic adoption condition, and the evaluation methodology (warmed-cache versus cold-start, cost analysis, network growth).
+* **The Unbrowse Maintenance Network paper** is the second-layer argument: trust, accountability, challenge mechanisms, and the narrow role of optional bonding once a shared graph carries meaningful traffic. It is explicit that the wedge works without a native asset and that the accountability layer is the quieter, later question.
+
+For current traction, prefer live numbers over anything written here. The public stats and traction endpoints carry the up-to-date figures; metrics pinned into prose go stale and should not be cited from a docs page.
+
+What is shipped today versus what is research direction is stated plainly in the Concepts section and in the [Open Source Notice](../OPEN-SOURCE-NOTICE.md). The honest split is the point: the wedge is measurable now, the fuller economy is documented intent.

--- a/docs/for-investors/the-moat.md
+++ b/docs/for-investors/the-moat.md
@@ -1,0 +1,9 @@
+# The Moat
+
+The defensibility is not the discovery technique; it is the maintained shared graph that compounds with use.
+
+Any single route can be reverse-engineered by anyone. What is hard to copy is a graph of routes that stays fresh as thousands of sites change, because that requires continuous traffic, feedback, and maintenance rather than a one-time scrape. The Maintenance Network paper makes exactly this distinction: a static registry decays, while a graph kept current by real usage is a productive asset whose value is its freshness, not its size.
+
+The reason this compounds is that every reused route makes the next agent's task cheaper, and every agent's feedback makes the graph more trustworthy, so usage and quality reinforce each other. That loop is the routing-infrastructure upside layered on the wedge: as more agent traffic routes through the graph, the graph becomes the cheaper default, and the cheaper default attracts more traffic.
+
+The honest boundary for diligence: the wedge is shipped and measurable today; the fuller accountability and route-economy layer is research direction documented in the papers, not a claim of current revenue mechanics.

--- a/docs/for-investors/the-wedge.md
+++ b/docs/for-investors/the-wedge.md
@@ -1,0 +1,7 @@
+# The Wedge
+
+Unbrowse's entry point is a narrow, provable claim: shared route lookup beats browser rediscovery on cost, latency, and reliability.
+
+The published research frames this as removing the browser-discovery tax, the recurring cost a browser-first agent pays to re-derive an unchanged workflow through DOM parsing, retries, and language-model reasoning on every run. Because agent workloads are repetitive, that tax is paid over and over for no reusable output. Eliminating it does not require a better model, only not redoing solved work, which is why the wedge stands on its own without any token or network economics attached.
+
+The strategic point for an investor is that the wedge is the qualifying claim, not the whole thesis: it is small enough to verify and large enough to pull adoption, and everything else is optional upside layered on a thing that already works.

--- a/docs/start-here/in-plain-english.md
+++ b/docs/start-here/in-plain-english.md
@@ -1,0 +1,15 @@
+# In Plain English
+
+Think of a website as having two layers: the front-of-house that humans see, and the request layer the browser quietly uses underneath.
+
+Traditional automation stays stuck in the front-of-house, clicking through the human interface. Unbrowse learns the request layer and reuses it, the way a regular at a restaurant skips the menu and orders the dish by name. Nothing about your permissions changes; the assistant still only does what you could already do yourself.
+
+This is usually faster and more reliable because the human interface is the brittle part: it changes layout, shows popups, and slows down, while the underlying request is comparatively stable. Reusing the stable layer means fewer surprises and far less waiting.
+
+A few things Unbrowse is not, to avoid a common misread:
+
+* It is not a permission bypass. It cannot reach anything you could not already reach yourself.
+* It does not publish your credentials. Sign-in stays on your machine.
+* It does not replace the browser everywhere. It uses one whenever a site genuinely needs it.
+
+If you want the operating model an AI agent actually follows, continue to For Agents.

--- a/docs/start-here/the-browser-discovery-tax.md
+++ b/docs/start-here/the-browser-discovery-tax.md
@@ -1,0 +1,9 @@
+# The Browser-Discovery Tax
+
+Every time an agent re-drives a website's interface, it pays a tax that produces nothing reusable.
+
+A browser-first agent that checks the same dashboard a hundred times performs the same DOM parsing, the same element lookups, the same retries, and the same language-model reasoning a hundred times. The published research calls this the browser-discovery tax: the recurring cost of rediscovering a workflow that has not changed. None of that work is saved for the next run, so the hundred-and-first visit costs exactly as much as the first.
+
+This matters because agent workloads are repetitive by nature. The same small set of tasks (read this inbox, list these events, fetch this price) runs over and over across many agents, and a browser-first design pays full price each time. Removing the tax does not require a smarter model; it requires not redoing solved work.
+
+Unbrowse exists to collect that solved work once and hand it back cheaply, which is the subject of the next page.

--- a/docs/start-here/the-shared-route-graph.md
+++ b/docs/start-here/the-shared-route-graph.md
@@ -1,0 +1,9 @@
+# The Shared Route Graph
+
+Unbrowse turns one agent's successful web task into a reusable route that other agents can call.
+
+When an agent completes a task through Unbrowse, the structured request path behind it (the route) is recorded with the information needed to run it again: the request shape, what it needs as input, what it returns, and how reliable it has been. That route goes into a shared graph, so the next agent with the same intent can look it up instead of rediscovering it from the visible page.
+
+The payoff compounds because web tasks are shared, not unique to one user. A route learned by the first agent that needed it saves every later agent the full discovery cost, the way a map drawn once spares everyone after from re-surveying the road. The graph also tracks which routes still work, so stale ones fall out of the way rather than misleading callers.
+
+A shared graph that many agents rely on raises its own question, which is how route quality is kept honest over time; that is covered in Concepts.

--- a/docs/start-here/what-is-unbrowse.md
+++ b/docs/start-here/what-is-unbrowse.md
@@ -1,0 +1,9 @@
+# What Is Unbrowse
+
+Unbrowse is a faster, cheaper, more reliable way for an AI agent to use a website.
+
+When an AI assistant books a flight, pulls a report, or posts an update, it usually controls a real browser: it opens the site, waits for the page, finds buttons, clicks, and re-reads the screen after every step. Every one of those steps can fail, and every one costs time and money. Unbrowse learns the request the browser was going to make underneath all that clicking, and makes that request directly the next time the same task comes up.
+
+The reason this is faster is that the slow part of web automation is not the network, it is the interface dance: rendering pages, locating elements, recovering from layout changes, and asking a language model what to click next. Skipping that dance when it is not needed turns a multi-second, failure-prone sequence into a single call. When the site truly needs a browser, for example to sign in or carry a session cookie, Unbrowse still uses one; it just stops paying that cost on every routine run.
+
+That is the whole idea: do the expensive discovery once, reuse the result, and keep a browser only where a browser is actually required.


### PR DESCRIPTION
## Why

The purge removed all explainer docs (correctly: they mixed sensitive internals with useful concepts). This rebuilds the **useful concept/explainer content only**, from authorized public sources, at the published-paper altitude. Restores a real docs/GitBook surface without re-leaking anything.

## Sources (authorized, public-altitude)

- arxiv [2604.00694](https://arxiv.org/abs/2604.00694) (the published core paper)
- The Unbrowse Maintenance Network paper (founder-authored, conceptual)
- Public positioning framework (L1 public / L2 investor ceiling)

## What

New `docs/` root GitBook, 23 files, 5 audience tracks: **Start Here** (normie PEEL), **For Agents** (resolve/execute model, MCP, browser fallback), **For Developers** (integration surfaces, conceptual route lifecycle, SDK quickstart), **Concepts** (shadow APIs, route graph as asset, the maintenance problem, trust/accountability at the paper's own restrained altitude, evaluation framing), **For Investors** (wedge/moat/market/read-the-papers, PEEL, no pinned metrics).

## Boundary held (verified)

- No implementation internals: no capture/DAG/anti-bot/payout mechanics. Grep-clean for `deep-reveng|anti-bot|toll-booth|control-point|cathedral|DAG recompute|kuri`.
- No L3/L4 disclosure. Investor track caps at L2 (wedge + hinted routing-infra upside).
- Coexists with the kept `docs/sdk/*` + `OPEN-SOURCE-NOTICE.md`; whitelist-copied, leak-guarded against re-introducing any purged path.
- No em dashes, no slop, internal links resolve.

## Action needed (cannot do from repo)

GitBook syncs `docs/whitepaper` (now absent). **Repoint the GitBook integration's project directory from `docs/whitepaper` to `docs/`** in the GitBook UI to bring it live. Source-of-truth companion: unbrowse-dev#462.

🤖 Generated with [Claude Code](https://claude.com/claude-code)